### PR TITLE
Fix sampling bug

### DIFF
--- a/R/bipartite_walk.R
+++ b/R/bipartite_walk.R
@@ -44,10 +44,9 @@ reverse_walk <- function(g, edges) {
 #' 
 #' @param g igraph graph
 #' @param edges graph.es object, edge sequence from g
-#' @param zeros.graph igraph graph or NULL
 #' 
 #' @return list or NULL
-bipartite_walk <- function(g, edges, zeros.graph = NULL) {
+bipartite_walk <- function(g, edges) {
 
   edges_to_add <- reverse_walk(g, edges)
   subgraph_to_add <- igraph::graph_from_edgelist(edges_to_add)
@@ -56,21 +55,23 @@ bipartite_walk <- function(g, edges, zeros.graph = NULL) {
     return(NULL)
   }
 
-  # if move to using igragh edge sequences, see "graph.es" object and "intersection" method
-  if (!is.null(zeros.graph)) {
+  return(edges_to_add)
+}
 
+
+check_structural_zeros <- function(b, zeros.graph) {
+  
     if (!igraph::is.directed(zeros.graph)) {
-      subgraph_to_add <- igraph::as.undirected(subgraph_to_add, mode = "collapse")
+      b <- igraph::as.undirected(b, mode = "collapse")
     }
 
     n_common_edges <- igraph::ecount(
-      igraph::intersection(subgraph_to_add, zeros.graph)
+      igraph::intersection(b, zeros.graph)
     )
 
     if (n_common_edges > 0) {
-      return(NULL)
+      return(FALSE)
     }
-  }
 
-  return(edges_to_add)
+    return(TRUE)
 }

--- a/R/move_pieces.R
+++ b/R/move_pieces.R
@@ -42,7 +42,7 @@ recursive_partition <- function(edges) {
 # TODO: find some test case for when n > 4
 
     n <- length(edges)
-    edges <- sample(edges, size = length(edges))
+    edges <- sample(edges, size = n)
 
     if (n == 1 || n == 2 || n == 3) {
         return(list(edges))

--- a/R/move_pieces.R
+++ b/R/move_pieces.R
@@ -14,9 +14,14 @@
 #' @return igraph.es
 sample_edges <- function(g, small.moves.coin = NULL) {
 
-    edges <- igraph::E(g)
+    m <- igraph::ecount(g)
 
-    subset_size <- sample(2:igraph::ecount(g), 1)
+    if (m == 1 || m == 2) {
+        subset_size <- m
+    } else {
+        subset_size <- sample(2:igraph::ecount(g), 1)
+    }
+    edges <- igraph::E(g)
 
     if (!is.null(small.moves.coin)) {
         if (runif(1) < small.moves.coin) {

--- a/R/move_pieces.R
+++ b/R/move_pieces.R
@@ -91,16 +91,14 @@ flatten_list <- function(x) {
 #' @param g igraph graph
 #' @param partitions list of igraph.es objects
 #' @param directed should the new edges be directed
-#' @param zeros.graph optional, igraph graph object
 #' 
 #' @return igraph object or NULL
-get_edges_to_add <- function(g, partitions, directed, zeros.graph = NULL) {
+get_edges_to_add <- function(g, partitions, directed) {
 
     new_edgelists <- lapply(
         X = partitions,
         FUN = bipartite_walk,
-        g = g,
-        zeros.graph = zeros.graph)
+        g = g)
 
     # if any of the results of bipartite_walk are NULL, return NULL
     if (sum(unlist(lapply(new_edgelists, is.null))) > 0) {
@@ -233,11 +231,10 @@ validate_type_3_move <- function(gdir, b_u) {
 #' 
 #' @param gdir igraph directed graph
 #' @param gudir igraph undirected graph
-#' @param zeros.graph optional, igraph graph (directed or undirected)
 #' @param small.moves.coin optional, numeric between (0, 1)
 #' 
 #' @return list(r = igraph.graph (directed), b = igraph.graph (directed) ) or NULL
-generate_type_2_move <- function(gdir, gudir, zeros.graph = NULL, small.moves.coin = NULL) {
+generate_type_2_move <- function(gdir, gudir, small.moves.coin = NULL) {
 
     r <- sample_edges(gdir, small.moves.coin = small.moves.coin)
     partitions <- flatten_list(recursive_partition(r))
@@ -246,8 +243,7 @@ generate_type_2_move <- function(gdir, gudir, zeros.graph = NULL, small.moves.co
     if (identical(partitions, list())) {
         return(NULL)
     }
-
-    b <- get_edges_to_add(gdir, partitions, directed = TRUE, zeros.graph = zeros.graph)
+    b <- get_edges_to_add(gdir, partitions, directed = TRUE)
 
     if (is.null(b)) {
         return(NULL)
@@ -288,16 +284,14 @@ validate_type_1_move <- function(gdir, gudir, r, b) {
     return(TRUE)
 }
 
-
 #' generate a Type 1 move
 #' 
 #' @param gdir igraph directed graph
 #' @param gudir igraph undirected graph
-#' @param zeros.graph optional, igraph graph (directed or undirected)
 #' @param small.moves.coin optional, numeric between (0, 1)
 #' 
 #' @return list(r=igraph.graph, b=igraph.graph) or NULL
-generate_type_1_move <- function(gdir, gudir, zeros.graph = NULL, small.moves.coin = NULL) {
+generate_type_1_move <- function(gdir, gudir, small.moves.coin = NULL) {
 
     directed_skeleton <- igraph::as.directed(gudir, mode = "arbitrary")
     r <- sample_edges(directed_skeleton, small.moves.coin = small.moves.coin)
@@ -307,7 +301,7 @@ generate_type_1_move <- function(gdir, gudir, zeros.graph = NULL, small.moves.co
     if (identical(partitions, list())) {
         return(NULL)
     }
-    b <- get_edges_to_add(directed_skeleton, partitions, directed = FALSE, zeros.graph = zeros.graph)
+    b <- get_edges_to_add(directed_skeleton, partitions, directed = FALSE)
 
     if (is.null(b)) {
         return(NULL)
@@ -326,19 +320,17 @@ generate_type_1_move <- function(gdir, gudir, zeros.graph = NULL, small.moves.co
 #' 
 #' @param gdir igraph directed graph
 #' @param gudir igraph undirected graph
-#' @param zeros.graph.dir optional, igraph directed graph
-#' @param zeros.graph.udir optional, igraph undirected graph
 #' @param small.moves.coin optional, numeric between (0, 1)
 #' 
 #' @return list(r_u=igraph.graph (undirected), b_u=igraph.graph (undirected), r_d=igraph.graph (directed), b_d=igraph.graph (directed)) or NULL
-generate_type_3_move <- function(gdir, gudir, zeros.graph.dir = NULL, zeros.graph.udir = NULL, small.moves.coin = NULL) {
+generate_type_3_move <- function(gdir, gudir, small.moves.coin = NULL) {
 
-    type_1_move <- generate_type_1_move(gdir, gudir, zeros.graph.dir, small.moves.coin)
+    type_1_move <- generate_type_1_move(gdir, gudir, small.moves.coin)
     if (is.null(type_1_move)) {
         return(NULL)
     } 
 
-    type_2_move <- generate_type_2_move(gdir, gudir, zeros.graph.udir, small.moves.coin)
+    type_2_move <- generate_type_2_move(gdir, gudir, small.moves.coin)
     if (is.null(type_2_move)) {
         return(NULL)
     }

--- a/R/move_pieces.R
+++ b/R/move_pieces.R
@@ -19,17 +19,17 @@ sample_edges <- function(g, small.moves.coin = NULL) {
     if (m == 1 || m == 2) {
         subset_size <- m
     } else {
-        subset_size <- sample(2:igraph::ecount(g), 1)
-    }
-    edges <- igraph::E(g)
 
-    if (!is.null(small.moves.coin)) {
-        if (runif(1) < small.moves.coin) {
-            subset_size <- sample(2:4, 1)
-        }
-    }
+        subset_size <- sample(2:m, 1)
 
-    edge_sample <- sample(edges, subset_size)
+        if (!is.null(small.moves.coin)) {
+            if (runif(1) < small.moves.coin) {
+                subset_size <- sample(2:min(m, 4), 1)
+            }
+        }   
+    }
+    
+    edge_sample <- sample(igraph::E(g), subset_size)
     return(edge_sample)
 }
 

--- a/R/move_pieces.R
+++ b/R/move_pieces.R
@@ -44,7 +44,7 @@ recursive_partition <- function(edges) {
     n <- length(edges)
     edges <- sample(edges, size = length(edges))
 
-    if (n == 2 || n == 3) {
+    if (n == 1 || n == 2 || n == 3) {
         return(list(edges))
     } else if (n == 4) {
         

--- a/R/move_pieces.R
+++ b/R/move_pieces.R
@@ -28,7 +28,7 @@ sample_edges <- function(g, small.moves.coin = NULL) {
             }
         }   
     }
-    
+
     edge_sample <- sample(igraph::E(g), subset_size)
     return(edge_sample)
 }
@@ -241,6 +241,12 @@ generate_type_2_move <- function(gdir, gudir, zeros.graph = NULL, small.moves.co
 
     r <- sample_edges(gdir, small.moves.coin = small.moves.coin)
     partitions <- flatten_list(recursive_partition(r))
+    partitions <- partitions[which(unlist(lapply(X=partitions, FUN=length)) > 1)]
+    
+    if (identical(partitions, list())) {
+        return(NULL)
+    }
+
     b <- get_edges_to_add(gdir, partitions, directed = TRUE, zeros.graph = zeros.graph)
 
     if (is.null(b)) {
@@ -296,6 +302,11 @@ generate_type_1_move <- function(gdir, gudir, zeros.graph = NULL, small.moves.co
     directed_skeleton <- igraph::as.directed(gudir, mode = "arbitrary")
     r <- sample_edges(directed_skeleton, small.moves.coin = small.moves.coin)
     partitions <- flatten_list(recursive_partition(r))
+    partitions <- partitions[which(unlist(lapply(X=partitions, FUN=length)) > 1)]
+    
+    if (identical(partitions, list())) {
+        return(NULL)
+    }
     b <- get_edges_to_add(directed_skeleton, partitions, directed = FALSE, zeros.graph = zeros.graph)
 
     if (is.null(b)) {

--- a/tests/testthat/test_bipartite_walk.R
+++ b/tests/testthat/test_bipartite_walk.R
@@ -29,49 +29,46 @@ testthat::test_that(
 testthat::test_that(
   "Test that bipartite_walk returns NULL when it tries to add a forbidden edge when zeros graph is undirected",
   {
-    g <- igraph::graph_from_edgelist(
+
+    b <- igraph::graph_from_edgelist(
     matrix(c(
-      c(1, 3),
-      c(2, 4),
-      c(3, 5),
-      c(4, 6)
-    ), nrow = 4, byrow = TRUE), directed = TRUE)
+      c(2, 3),
+      c(2, 4)
+    ), ncol = 2, byrow = TRUE), directed = TRUE)
 
     zeros.graph <- igraph::graph_from_edgelist(
      matrix(c(
       c(2, 3),
       c(3, 4),
       c(4, 5),
-      c(1, 6)), nrow = 4, byrow = TRUE), directed = FALSE
+      c(1, 6)), ncol = 2, byrow = TRUE), directed = FALSE
     )
 
-    result <- bipartite_walk(g, igraph::E(g), zeros.graph = zeros.graph)
-    testthat::expect_null(result)
+    result <- check_structural_zeros(b = b, zeros.graph = zeros.graph)
+    testthat::expect_false(result)
   }
 )
 
 
 testthat::test_that(
-  "Test that bipartite_walk returns NULL when it tries to add a forbidden edge when zeros graph is directed",
+  "Test that check_structural_zeros() returns FALSE when it tries to add a forbidden edge when zeros graph is directed",
   {
-    g <- igraph::graph_from_edgelist(
+    b <- igraph::graph_from_edgelist(
     matrix(c(
-      c(1, 3),
-      c(2, 4),
-      c(3, 5),
-      c(4, 6)
-    ), nrow = 4, byrow = TRUE), directed = TRUE)
+      c(2, 3),
+      c(2, 4)
+    ), ncol = 2, byrow = TRUE), directed = TRUE)
 
     zeros.graph <- igraph::graph_from_edgelist(
      matrix(c(
       c(2, 3),
       c(3, 4),
       c(4, 5),
-      c(1, 6)), nrow = 4, byrow = TRUE)
+      c(1, 6)), ncol = 2, byrow = TRUE)
     )
 
-    result <- bipartite_walk(g, igraph::E(g), zeros.graph = zeros.graph)
-    testthat::expect_null(result)
+    result <- check_structural_zeros(b = b, zeros.graph = zeros.graph)
+    testthat::expect_false(result)
   }
 )
 

--- a/tests/testthat/test_move_pieces.R
+++ b/tests/testthat/test_move_pieces.R
@@ -27,6 +27,20 @@ testthat::test_that(
     }
 )
 
+testthat::test_that(
+    "Test that sample_edges returns sets of length 1 and 2, resp. when G contains only 1 or 2 edges",
+    {
+        G1 <- igraph::erdos.renyi.game(n = 10, p.or.m = 1, directed = TRUE, type = "gnm")
+        G2 <- igraph::erdos.renyi.game(n = 10, p.or.m = 2, directed = TRUE, type = "gnm")
+
+        edge_sample_1 <- sample_edges(G1)
+        edge_sample_2 <- sample_edges(G2)
+
+        testthat::expect_equal(length(edge_sample_1), 1)
+        testthat::expect_equal(length(edge_sample_2), 2)
+    }
+)
+
 
 ######################################
 ####### recursive_partition() ########

--- a/tests/testthat/test_move_pieces.R
+++ b/tests/testthat/test_move_pieces.R
@@ -457,6 +457,17 @@ testthat::test_that(
     }
 )
 
+testthat::test_that(
+    "Thest that generate_type_2_move() returns NULL when partitions contain a single edge",
+    {
+
+        gdir <- igraph::erdos.renyi.game(n = 3, p.or.m = 1, directed = TRUE, type = "gnm")
+
+        result <- generate_type_2_move(gdir, NULL, NULL, NULL)
+        testthat::expect_null(result)
+    }
+)
+
 
 
 ######################################
@@ -533,6 +544,17 @@ testthat::test_that(
     }
 )
 
+
+testthat::test_that(
+    "Thest that generate_type_1_move() returns NULL when partitions contain a single edge",
+    {
+
+        gudir <- igraph::erdos.renyi.game(n = 3, p.or.m = 1, directed = FALSE, type = "gnm")
+
+        result <- generate_type_1_move(NULL, gudir, NULL, NULL)
+        testthat::expect_null(result)
+    }
+)
 
 ######################################
 ###### apply_type_1_move() ###########

--- a/tests/testthat/test_move_pieces.R
+++ b/tests/testthat/test_move_pieces.R
@@ -445,7 +445,7 @@ testthat::test_that(
 
         set.seed(42)
 
-        result <- generate_type_2_move(gdir, gudir, NULL, NULL)
+        result <- generate_type_2_move(gdir, gudir, NULL)
         result_move <- igraph::union(
             igraph::difference(gdir, result$r), result$b
         )
@@ -463,7 +463,7 @@ testthat::test_that(
 
         gdir <- igraph::erdos.renyi.game(n = 3, p.or.m = 1, directed = TRUE, type = "gnm")
 
-        result <- generate_type_2_move(gdir, NULL, NULL, NULL)
+        result <- generate_type_2_move(gdir, NULL, NULL)
         testthat::expect_null(result)
     }
 )
@@ -538,7 +538,7 @@ testthat::test_that(
             ), ncol = 2, byrow = TRUE), directed = FALSE)
 
         set.seed(1234)
-        result <- generate_type_1_move(gdir, gudir, NULL, NULL)
+        result <- generate_type_1_move(gdir, gudir, NULL)
 
         testthat::expect_equal(sum(degree(b_expected) - degree(result$b)), 0)
     }
@@ -551,7 +551,7 @@ testthat::test_that(
 
         gudir <- igraph::erdos.renyi.game(n = 3, p.or.m = 1, directed = FALSE, type = "gnm")
 
-        result <- generate_type_1_move(NULL, gudir, NULL, NULL)
+        result <- generate_type_1_move(NULL, gudir, NULL)
         testthat::expect_null(result)
     }
 )
@@ -657,7 +657,7 @@ testthat::test_that(
             ), ncol = 2, byrow = TRUE), directed = FALSE)
 
         set.seed(4)
-        results <- generate_type_3_move(gdir, gudir, NULL, NULL, NULL)
+        results <- generate_type_3_move(gdir, gudir, NULL)
 
         testthat::expect_true(igraph::isomorphic(results$b_d, b_d))
         testthat::expect_true(igraph::isomorphic(results$b_u, b_u))

--- a/tests/testthat/test_move_pieces.R
+++ b/tests/testthat/test_move_pieces.R
@@ -49,17 +49,21 @@ testthat::test_that(
 testthat::test_that(
     "Test that recursive_partition returns correct output lengths for n=2,3,4",
     {
+        G1 <- igraph::erdos.renyi.game(n = 3, p.or.m = 1, directed = TRUE, type = "gnm")
         G2 <- igraph::erdos.renyi.game(n = 3, p.or.m = 2, directed = TRUE, type = "gnm")
         G3 <- igraph::erdos.renyi.game(n = 3, p.or.m = 3, directed = TRUE, type = "gnm")
         G4 <- igraph::erdos.renyi.game(n = 4, p.or.m = 4, directed = TRUE, type = "gnm")
 
+        edges1 <- recursive_partition(E(G1))
         edges2 <- recursive_partition(E(G2))
         edges3 <- recursive_partition(E(G3))
         edges4 <- recursive_partition(E(G4))
 
+        testthat::expect_length(edges1, 1)
         testthat::expect_length(edges2, 1)
         testthat::expect_length(edges3, 1)
         testthat::expect_true(length(edges4) == 2 || length(edges4) == 1)
+        testthat::expect_length(edges1[[1]], 1)
         testthat::expect_length(edges2[[1]], 2)
         testthat::expect_length(edges3[[1]], 3)
     }


### PR DESCRIPTION
This resolves #32 and unblocks progress on #37. 

What I did is fix how the `sample_edges` function handles the case where there are only 1 or 2 edges in the graph being sampled by simply returning the edge set. This later gets passed to `recursive_partition` where I added a case to handle a single edge by simply passing it on. 

I then added logic in the move generator functions to filter out any edge partitions with only a single edge and to return NULL if all partitions contained single edges. 