### PR TITLE
Split directed

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -64,3 +64,13 @@ reciprocated_edges <- function(g) {
     g=g
   )
 }
+
+split_directed <- function(g) {
+  recip_idx <- reciprocated_edges(g)
+  return(
+    list(
+      gudir=igraph::as.undirected(igraph::subgraph.edges(g, igraph::E(g)[recip_idx], delete.vertices=FALSE), mode="collapse"),
+      gdir=igraph::subgraph.edges(g, igraph::E(g)[!recip_idx], delete.vertices=FALSE)
+    )
+  )
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -55,3 +55,12 @@ validate_bidirected_graph_part <- function(g, type){
   validate_undirected(g, type)            # check if graph is undirected
   validate_simple(g, type)                # check if graph is simple
 }
+
+reciprocated_edges <- function(g) {
+  apply(
+    X=igraph::ends(g, igraph::E(g), names=FALSE),
+    MARGIN=1,
+    FUN = function(e,g){e[1] %in% igraph::neighbors(g, e[2], mode="out")},
+    g=g
+  )
+}

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -1,0 +1,26 @@
+testthat::context("Testing files in test_utils.R other than input validation functions")
+
+
+testthat::test_that(
+    "Test that reciprocated_edges() returns expected output", 
+    {
+        g <- igraph::graph_from_edgelist(
+            matrix(
+                c(
+                    c(2, 1),
+                    c(1, 3),
+                    c(2, 3),
+                    c(3, 4),
+                    c(4, 3),
+                    c(4, 5),
+                    c(4, 5),
+                    c(5, 4)
+                ), ncol=2, byrow=TRUE)
+        )
+
+        expected_result <- c(rep(FALSE, 3), rep(TRUE, 5))
+        result <- reciprocated_edges(g)
+        expect_array_equal(expected_result, result)
+
+    }
+)

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -24,3 +24,31 @@ testthat::test_that(
 
     }
 )
+
+
+testthat::test_that(
+    "Test that split_directed() returns expected output",
+    {
+        G <- igraph::graph_from_edgelist(
+            matrix(
+            c(
+                c(1,3),
+                c(2,1),
+                c(3,2),
+                c(3,4),
+                c(4,3),
+                c(4,5),
+                c(4,5),
+                c(5,4)), ncol=2, byrow=TRUE), directed=TRUE)
+
+
+        gdir <- add_edges(igraph::make_empty_graph(5), c(2,1,1,3,3,2))
+        gudir <- add_edges(igraph::make_empty_graph(5, directed=FALSE), c(3,4,4,5))
+
+        result <- split_directed(G)
+
+        testthat::expect_true(igraph::isomorphic(result$gdir, gdir))
+        testthat::expect_true(igraph::isomorphic(result$gudir, gudir))
+
+    }
+)


### PR DESCRIPTION
Currently the split_directed() function will return empty graphs if there are no directed/bidirected edges, respectively. Is this the behavior we want?